### PR TITLE
feat: bump version and change name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,8 @@
-on: [push]
+on:
+  push:
+    branches:
+    - main
+  pull_request:
 
 jobs:
   install_fdb:

--- a/action.yml
+++ b/action.yml
@@ -1,11 +1,11 @@
-name: Install foundationdb
-description: Install foundationdb
+name: Setup foundationDB
+description: Setup a FoundationDB
 branding:
   icon: database
-  color: black
+  color: blue
 inputs:
   version:
-    description: Foundationdb version to install
+    description: FoundationDB version to install
     required: false
     default: "6.3.22"
 runs:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "foundationdb-actions-install",
-  "version": "1.0.2",
-  "description": "Github Action for installing foundationdb",
+  "version": "2.0.0",
+  "description": "Github Action for installing foundationDB",
   "main": "index.js",
   "scripts": {
     "build": "ncc build index.js -o dist"


### PR DESCRIPTION
"Install foundationdb" is owned by Clikengo, so we need to have a new one.