### PR TITLE
feat: add arm64 support on osx

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,11 +6,24 @@ on:
 
 jobs:
   install_fdb:
-    name: Install
+    name: Install FDB ${{ matrix.fdb_version }} on ${{ matrix.os }}
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13]
+        include:
+          # macOS test variations
+          - os: macos-13
+            fdb_version: '7.3.66'
+          - os: macos-14
+            fdb_version: '7.3.66'
+
+          # Linux test variations
+          - os: ubuntu-latest
+            fdb_version: '6.3.25'
+          - os: ubuntu-latest
+            fdb_version: '7.1.59'
+          - os: ubuntu-latest
+            fdb_version: '7.3.66'
 
     runs-on: ${{ matrix.os }}
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -2886,9 +2886,13 @@ try {
             break;
         }
         case 'darwin': {
-            let url = `${base_url}/FoundationDB-${version}_x86_64.pkg`;
+            let arch = os.arch();
+            let arch_suffix = arch === 'arm64' ? 'arm64' : 'x86_64';
+            let url = `${base_url}/FoundationDB-${version}_${arch_suffix}.pkg`;
+            let pkg_name = `FoundationDB-${version}_${arch_suffix}.pkg`;
+
             exec(`curl -L -O ${url}`);
-            exec(`sudo installer -pkg FoundationDB-${version}_x86_64.pkg -target /`);
+            exec(`sudo installer -pkg ${pkg_name} -target /`);
             break;
         }
         default:

--- a/index.js
+++ b/index.js
@@ -25,9 +25,13 @@ try {
             break;
         }
         case 'darwin': {
-            let url = `${base_url}/FoundationDB-${version}_x86_64.pkg`;
+            let arch = os.arch();
+            let arch_suffix = arch === 'arm64' ? 'arm64' : 'x86_64';
+            let url = `${base_url}/FoundationDB-${version}_${arch_suffix}.pkg`;
+            let pkg_name = `FoundationDB-${version}_${arch_suffix}.pkg`;
+
             exec(`curl -L -O ${url}`);
-            exec(`sudo installer -pkg FoundationDB-${version}_x86_64.pkg -target /`);
+            exec(`sudo installer -pkg ${pkg_name} -target /`);
             break;
         }
         default:


### PR DESCRIPTION
`macos-14` is `macOS 14 Arm64` according to https://github.com/actions/runner-images?tab=readme-ov-file#available-images


Should be a prerequisite to https://github.com/foundationdb-rs/foundationdb-rs/issues/140